### PR TITLE
isPlainObject() to support objects from another window

### DIFF
--- a/packages/mobx-state-tree/src/utils.ts
+++ b/packages/mobx-state-tree/src/utils.ts
@@ -1,6 +1,8 @@
 import { isObservableArray, $mobx, getAtom } from "mobx"
 import { Primitives } from "./core/type/type"
 
+const plainObjectString = Object.toString()
+
 /**
  * @internal
  * @hidden
@@ -123,7 +125,8 @@ export function extend(a: any, ...b: any[]) {
 export function isPlainObject(value: any): value is { [k: string]: any } {
     if (value === null || typeof value !== "object") return false
     const proto = Object.getPrototypeOf(value)
-    return proto === Object.prototype || proto === null
+    if (proto == null) return true
+    return proto.constructor?.toString() === plainObjectString
 }
 
 /**


### PR DESCRIPTION
Same issue as in MobX:
https://github.com/mobxjs/mobx/issues/2448

Which was recently patched in:
https://github.com/mobxjs/mobx/pull/2461